### PR TITLE
fix(scripts): install-host-deps curl retry

### DIFF
--- a/helm-chart/boathouse/Chart.yaml
+++ b/helm-chart/boathouse/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for deploying boathouse
 name: boathouse
-version: 0.1.1
+version: 0.1.2

--- a/helm-chart/boathouse/templates/configmap/boathouse-scripts.yaml
+++ b/helm-chart/boathouse/templates/configmap/boathouse-scripts.yaml
@@ -25,7 +25,18 @@ data:
         apt-get update
         apt-get install -y fuse
         rm -f /usr/bin/goofys
-        curl -L -o /usr/bin/goofys https://github.com/StatCan/goofys/releases/download/v0.24.0-statcan-3/goofys
+        curl --connect-timeout 5 \
+             --max-time 10 \
+             --retry 10 \
+             --retry-delay 0 \
+             --retry-max-time 120 \
+             -L -o /usr/bin/goofys https://github.com/StatCan/goofys/releases/download/v0.24.0-statcan-2/goofys
+
+        if [ ! -f /usr/bin/goofys ]  ; then
+            echo "Could not download goofys"
+            exit 1
+        fi
+        
         chmod +x /usr/bin/goofys
     }
 


### PR DESCRIPTION
- Tune curl retry options, fail container if not successful

The install-host-deps container has been randomly/silently failing (with a `curl: (6) Could not resolve host: github.com`) and causing the mounting of minio folders to not mount on some nodes as a result. Since the issue is so intermittent it is hard to tell the cause, solution is to make the download more reliable and obvious if it fails.
